### PR TITLE
feat: initial attendance app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL="postgresql://user:password@localhost:5432/attendance?schema=public"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.env
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# attendance-system
+# Attendance System
+
+Monolithic Next.js app for managing class rosters and attendance with PostgreSQL and Prisma.
+
+## Setup
+
+1. Install dependencies: `npm install`
+2. Copy `.env.example` to `.env` and adjust the `DATABASE_URL`.
+3. Run Prisma migrations: `npx prisma migrate dev`
+4. Start the app: `npm run dev`

--- a/app/api/rosters/[id]/export/route.js
+++ b/app/api/rosters/[id]/export/route.js
@@ -1,0 +1,20 @@
+import { prisma } from '@/lib/prisma';
+import * as XLSX from 'xlsx';
+
+export async function GET(req, { params }) {
+  const rosterId = Number(params.id);
+  const students = await prisma.student.findMany({ where: { rosterId } });
+  const rows = students.map((s) => ({
+    enrollmentNumber: s.enrollmentNumber,
+    name: s.name,
+    ...(s.extra || {}),
+  }));
+  const sheet = XLSX.utils.json_to_sheet(rows);
+  const csv = XLSX.utils.sheet_to_csv(sheet);
+  return new Response('\ufeff' + csv, {
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': 'attachment; filename="roster.csv"',
+    },
+  });
+}

--- a/app/api/rosters/[id]/import/route.js
+++ b/app/api/rosters/[id]/import/route.js
@@ -1,0 +1,46 @@
+import { prisma } from '@/lib/prisma';
+import * as XLSX from 'xlsx';
+
+export async function POST(req, { params }) {
+  const rosterId = Number(params.id);
+  try {
+    const form = await req.formData();
+    const file = form.get('file');
+    if (!file) throw new Error('File required');
+    const buf = Buffer.from(await file.arrayBuffer());
+    const workbook = XLSX.read(buf, { type: 'buffer' });
+    const sheet = workbook.Sheets[workbook.SheetNames[0]];
+    const rows = XLSX.utils.sheet_to_json(sheet, { defval: '' });
+    const students = rows
+      .map((row) => {
+        const { enrollmentNumber, name, ...extra } = row;
+        return {
+          enrollmentNumber: String(enrollmentNumber),
+          name: String(name),
+          extra,
+        };
+      })
+      .filter((s) => s.enrollmentNumber && s.name);
+    const unique = Object.values(
+      students.reduce((acc, s) => {
+        acc[s.enrollmentNumber] = s;
+        return acc;
+      }, {})
+    );
+    const created = await prisma.$transaction(async (tx) => {
+      const results = [];
+      for (const s of unique) {
+        const student = await tx.student.upsert({
+          where: { rosterId_enrollmentNumber: { rosterId, enrollmentNumber: s.enrollmentNumber } },
+          update: { name: s.name, extra: s.extra },
+          create: { rosterId, name: s.name, enrollmentNumber: s.enrollmentNumber, extra: s.extra },
+        });
+        results.push(student);
+      }
+      return results;
+    });
+    return Response.json({ ok: true, students: created });
+  } catch (e) {
+    return Response.json({ ok: false, error: e.message }, { status: 400 });
+  }
+}

--- a/app/api/rosters/[id]/students/route.js
+++ b/app/api/rosters/[id]/students/route.js
@@ -1,0 +1,42 @@
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+
+const studentSchema = z.object({
+  name: z.string().min(1),
+  enrollmentNumber: z.string().min(1),
+  extra: z.record(z.any()).optional(),
+  notes: z.string().optional(),
+});
+
+export async function GET(req, { params }) {
+  const rosterId = Number(params.id);
+  const students = await prisma.student.findMany({
+    where: { rosterId },
+    orderBy: { id: 'asc' },
+  });
+  return Response.json({ ok: true, students });
+}
+
+export async function POST(req, { params }) {
+  const rosterId = Number(params.id);
+  try {
+    const data = await req.json();
+    const students = z.array(studentSchema).parse(data.students);
+    const created = await prisma.$transaction(async (tx) => {
+      const results = [];
+      for (const s of students) {
+        const { enrollmentNumber, name, extra, notes } = s;
+        const student = await tx.student.upsert({
+          where: { rosterId_enrollmentNumber: { rosterId, enrollmentNumber } },
+          update: { name, extra, notes },
+          create: { rosterId, name, enrollmentNumber, extra, notes },
+        });
+        results.push(student);
+      }
+      return results;
+    });
+    return Response.json({ ok: true, students: created });
+  } catch (e) {
+    return Response.json({ ok: false, error: e.message }, { status: 400 });
+  }
+}

--- a/app/api/rosters/route.js
+++ b/app/api/rosters/route.js
@@ -1,0 +1,20 @@
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+
+export async function GET() {
+  const rosters = await prisma.roster.findMany({ orderBy: { id: 'desc' } });
+  return Response.json({ ok: true, rosters });
+}
+
+const rosterSchema = z.object({ name: z.string().min(1) });
+
+export async function POST(req) {
+  try {
+    const data = await req.json();
+    const { name } = rosterSchema.parse(data);
+    const roster = await prisma.roster.create({ data: { name } });
+    return Response.json({ ok: true, roster });
+  } catch (e) {
+    return Response.json({ ok: false, error: e.message }, { status: 400 });
+  }
+}

--- a/app/api/sessions/[id]/export/route.js
+++ b/app/api/sessions/[id]/export/route.js
@@ -1,0 +1,24 @@
+import { prisma } from '@/lib/prisma';
+import * as XLSX from 'xlsx';
+
+export async function GET(req, { params }) {
+  const sessionId = Number(params.id);
+  const records = await prisma.attendanceRecord.findMany({
+    where: { sessionId },
+    include: { student: true },
+  });
+  const rows = records.map((r) => ({
+    enrollmentNumber: r.student.enrollmentNumber,
+    name: r.student.name,
+    status: r.status,
+    ...(r.student.extra || {}),
+  }));
+  const sheet = XLSX.utils.json_to_sheet(rows);
+  const csv = XLSX.utils.sheet_to_csv(sheet);
+  return new Response('\ufeff' + csv, {
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': 'attachment; filename="session.csv"',
+    },
+  });
+}

--- a/app/api/sessions/[id]/route.js
+++ b/app/api/sessions/[id]/route.js
@@ -1,0 +1,48 @@
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+
+const updateSchema = z.object({
+  records: z.array(
+    z.object({ studentId: z.number(), status: z.enum(['PRESENT', 'ABSENT']) })
+  ),
+  locked: z.boolean().optional(),
+});
+
+export async function GET(req, { params }) {
+  const sessionId = Number(params.id);
+  const session = await prisma.attendanceSession.findUnique({
+    where: { id: sessionId },
+    include: {
+      roster: true,
+      records: { include: { student: true } },
+    },
+  });
+  if (!session)
+    return Response.json({ ok: false, error: 'Not found' }, { status: 404 });
+  return Response.json({ ok: true, session });
+}
+
+export async function POST(req, { params }) {
+  const sessionId = Number(params.id);
+  try {
+    const data = await req.json();
+    const { records, locked } = updateSchema.parse(data);
+    await prisma.$transaction(async (tx) => {
+      for (const r of records) {
+        await tx.attendanceRecord.update({
+          where: { sessionId_studentId: { sessionId, studentId: r.studentId } },
+          data: { status: r.status },
+        });
+      }
+      if (locked !== undefined) {
+        await tx.attendanceSession.update({
+          where: { id: sessionId },
+          data: { locked },
+        });
+      }
+    });
+    return Response.json({ ok: true });
+  } catch (e) {
+    return Response.json({ ok: false, error: e.message }, { status: 400 });
+  }
+}

--- a/app/api/sessions/route.js
+++ b/app/api/sessions/route.js
@@ -1,0 +1,51 @@
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+
+const createSchema = z.object({
+  subject: z.string().min(1),
+  rosterId: z.coerce.number(),
+  sessionDate: z.coerce.date(),
+});
+
+export async function GET() {
+  const sessions = await prisma.attendanceSession.findMany({
+    include: { roster: true, records: true },
+    orderBy: { sessionDate: 'desc' },
+  });
+  const formatted = sessions.map((s) => ({
+    id: s.id,
+    subject: s.subject,
+    sessionDate: s.sessionDate,
+    rosterName: s.roster.name,
+    present: s.records.filter((r) => r.status === 'PRESENT').length,
+    absent: s.records.filter((r) => r.status === 'ABSENT').length,
+    locked: s.locked,
+  }));
+  return Response.json({ ok: true, sessions: formatted });
+}
+
+export async function POST(req) {
+  try {
+    const data = await req.json();
+    const { subject, rosterId, sessionDate } = createSchema.parse(data);
+    const students = await prisma.student.findMany({ where: { rosterId } });
+    const session = await prisma.$transaction(async (tx) => {
+      const s = await tx.attendanceSession.create({
+        data: { subject, rosterId, sessionDate },
+      });
+      if (students.length) {
+        await tx.attendanceRecord.createMany({
+          data: students.map((st) => ({
+            sessionId: s.id,
+            studentId: st.id,
+            status: 'PRESENT',
+          })),
+        });
+      }
+      return s;
+    });
+    return Response.json({ ok: true, session });
+  } catch (e) {
+    return Response.json({ ok: false, error: e.message }, { status: 400 });
+  }
+}

--- a/app/attendance/[id]/page.jsx
+++ b/app/attendance/[id]/page.jsx
@@ -1,0 +1,33 @@
+import { prisma } from '@/lib/prisma';
+import AttendanceTable from '@/components/AttendanceTable';
+
+export default async function AttendanceSessionPage({ params }) {
+  const sessionId = Number(params.id);
+  const session = await prisma.attendanceSession.findUnique({
+    where: { id: sessionId },
+    include: {
+      roster: true,
+      records: { include: { student: true } },
+    },
+  });
+  if (!session) return <div>Session not found</div>;
+
+  const records = session.records.map((r) => ({
+    id: r.id,
+    studentId: r.studentId,
+    name: r.student.name,
+    enrollmentNumber: r.student.enrollmentNumber,
+    extra: r.student.extra,
+    status: r.status,
+  }));
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-2">{session.subject}</h1>
+      <p className="mb-4">
+        {session.sessionDate.toISOString().slice(0, 10)} – {session.roster.name}
+      </p>
+      <AttendanceTable sessionId={session.id} locked={session.locked} records={records} />
+    </div>
+  );
+}

--- a/app/attendance/page.jsx
+++ b/app/attendance/page.jsx
@@ -1,0 +1,64 @@
+import { prisma } from '@/lib/prisma';
+import { redirect } from 'next/navigation';
+
+export default async function NewAttendancePage() {
+  const rosters = await prisma.roster.findMany({ orderBy: { name: 'asc' } });
+  const today = new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Karachi' });
+
+  async function createSession(formData) {
+    'use server';
+    const subject = formData.get('subject');
+    const date = formData.get('date');
+    const rosterId = Number(formData.get('rosterId'));
+    if (!subject || !date || !rosterId) return;
+    const session = await prisma.$transaction(async (tx) => {
+      const students = await tx.student.findMany({ where: { rosterId } });
+      const s = await tx.attendanceSession.create({
+        data: { subject, sessionDate: new Date(date), rosterId },
+      });
+      if (students.length) {
+        await tx.attendanceRecord.createMany({
+          data: students.map((st) => ({
+            sessionId: s.id,
+            studentId: st.id,
+            status: 'PRESENT',
+          })),
+        });
+      }
+      return s;
+    });
+    redirect(`/attendance/${session.id}`);
+  }
+
+  return (
+    <form action={createSession} className="space-y-4">
+      <h1 className="text-2xl font-bold">New Attendance</h1>
+      <div>
+        <label className="block mb-1">Subject</label>
+        <input name="subject" className="border p-2 w-full" required />
+      </div>
+      <div>
+        <label className="block mb-1">Date</label>
+        <input
+          type="date"
+          name="date"
+          defaultValue={today}
+          className="border p-2 w-full"
+          required
+        />
+      </div>
+      <div>
+        <label className="block mb-1">Roster</label>
+        <select name="rosterId" className="border p-2 w-full" required>
+          <option value="">Select roster</option>
+          {rosters.map((r) => (
+            <option key={r.id} value={r.id}>
+              {r.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <button className="bg-blue-500 text-white px-4 py-2 rounded">Create</button>
+    </form>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-50 text-gray-900;
+}
+
+.table-row-present {
+  @apply bg-green-100;
+}
+
+.table-row-absent {
+  @apply bg-red-100;
+}

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,0 +1,15 @@
+import './globals.css';
+
+export const metadata = {
+  title: 'Attendance System',
+};
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen">
+        <main className="max-w-5xl mx-auto p-4">{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+
+export default function HomePage() {
+  const cards = [
+    { href: '/attendance', title: 'Take Attendance' },
+    { href: '/sessions', title: 'Attendance History' },
+    { href: '/rosters', title: 'Manage Lists / Add Students' },
+  ];
+
+  return (
+    <div className="grid gap-6 sm:grid-cols-3 mt-10">
+      {cards.map((c) => (
+        <Link
+          key={c.href}
+          href={c.href}
+          className="flex items-center justify-center h-40 rounded-lg bg-white shadow hover:bg-gray-100"
+        >
+          {c.title}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/app/rosters/[id]/page.jsx
+++ b/app/rosters/[id]/page.jsx
@@ -1,0 +1,104 @@
+import { prisma } from '@/lib/prisma';
+import * as XLSX from 'xlsx';
+
+export default async function RosterPage({ params }) {
+  const rosterId = Number(params.id);
+  const roster = await prisma.roster.findUnique({
+    where: { id: rosterId },
+    include: { students: true },
+  });
+  if (!roster) return <div>Roster not found</div>;
+
+  const extraKeys = Array.from(
+    new Set(
+      roster.students.flatMap((s) => (s.extra ? Object.keys(s.extra) : []))
+    )
+  );
+
+  async function importAction(formData) {
+    'use server';
+    const file = formData.get('file');
+    if (!file || typeof file === 'string') return;
+    const buf = Buffer.from(await file.arrayBuffer());
+    const workbook = XLSX.read(buf, { type: 'buffer' });
+    const sheet = workbook.Sheets[workbook.SheetNames[0]];
+    const rows = XLSX.utils.sheet_to_json(sheet, { defval: '' });
+    const students = rows
+      .map((row) => {
+        const { enrollmentNumber, name, ...extra } = row;
+        return {
+          enrollmentNumber: String(enrollmentNumber),
+          name: String(name),
+          extra,
+        };
+      })
+      .filter((s) => s.enrollmentNumber && s.name);
+    const unique = Object.values(
+      students.reduce((acc, s) => {
+        acc[s.enrollmentNumber] = s;
+        return acc;
+      }, {})
+    );
+    await prisma.$transaction(async (tx) => {
+      for (const s of unique) {
+        await tx.student.upsert({
+          where: { rosterId_enrollmentNumber: { rosterId, enrollmentNumber: s.enrollmentNumber } },
+          update: { name: s.name, extra: s.extra },
+          create: { rosterId, name: s.name, enrollmentNumber: s.enrollmentNumber, extra: s.extra },
+        });
+      }
+    });
+  }
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">{roster.name}</h1>
+      <form
+        action={importAction}
+        className="mb-4 flex gap-2"
+        encType="multipart/form-data"
+      >
+        <input
+          type="file"
+          name="file"
+          accept=".xlsx,.csv"
+          className="flex-grow"
+          required
+        />
+        <button className="bg-blue-500 text-white px-4 py-2 rounded">Import</button>
+        <a
+          href={`/api/rosters/${rosterId}/export`}
+          className="bg-green-500 text-white px-4 py-2 rounded"
+        >
+          Export CSV
+        </a>
+      </form>
+      <div className="overflow-auto">
+        <table className="min-w-full bg-white rounded shadow">
+          <thead>
+            <tr>
+              <th className="p-2 text-left">Enrollment</th>
+              <th className="p-2 text-left">Name</th>
+              {extraKeys.map((k) => (
+                <th key={k} className="p-2 text-left">
+                  {k}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {roster.students.map((s) => (
+              <tr key={s.id} className="border-t">
+                <td className="p-2">{s.enrollmentNumber}</td>
+                <td className="p-2">{s.name}</td>
+                {extraKeys.map((k) => (
+                  <td key={k} className="p-2">{s.extra?.[k] || ''}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/app/rosters/page.jsx
+++ b/app/rosters/page.jsx
@@ -1,0 +1,36 @@
+import Link from 'next/link';
+import { prisma } from '@/lib/prisma';
+
+export default async function RostersPage() {
+  const rosters = await prisma.roster.findMany({ orderBy: { id: 'desc' } });
+
+  async function createRoster(formData) {
+    'use server';
+    const name = formData.get('name');
+    if (!name) return;
+    await prisma.roster.create({ data: { name } });
+  }
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Rosters</h1>
+      <form action={createRoster} className="mb-4 flex gap-2">
+        <input
+          type="text"
+          name="name"
+          placeholder="New roster name"
+          className="border p-2 flex-grow"
+          required
+        />
+        <button className="bg-blue-500 text-white px-4 py-2 rounded">Add</button>
+      </form>
+      <ul className="space-y-2">
+        {rosters.map((r) => (
+          <li key={r.id} className="p-2 bg-white rounded shadow">
+            <Link href={`/rosters/${r.id}`}>{r.name}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/sessions/page.jsx
+++ b/app/sessions/page.jsx
@@ -1,0 +1,53 @@
+import Link from 'next/link';
+import { prisma } from '@/lib/prisma';
+
+export default async function SessionsPage() {
+  const sessions = await prisma.attendanceSession.findMany({
+    include: { roster: true, records: true },
+    orderBy: { sessionDate: 'desc' },
+  });
+  const rows = sessions.map((s) => ({
+    id: s.id,
+    subject: s.subject,
+    sessionDate: s.sessionDate,
+    rosterName: s.roster.name,
+    present: s.records.filter((r) => r.status === 'PRESENT').length,
+    absent: s.records.filter((r) => r.status === 'ABSENT').length,
+    locked: s.locked,
+  }));
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Attendance History</h1>
+      <div className="overflow-auto">
+        <table className="min-w-full bg-white rounded shadow">
+          <thead>
+            <tr>
+              <th className="p-2 text-left">Date</th>
+              <th className="p-2 text-left">Subject</th>
+              <th className="p-2 text-left">Roster</th>
+              <th className="p-2 text-right">Present</th>
+              <th className="p-2 text-right">Absent</th>
+              <th className="p-2 text-center">Locked</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.id} className="border-t">
+                <td className="p-2">{r.sessionDate.toISOString().slice(0, 10)}</td>
+                <td className="p-2">
+                  <Link href={`/attendance/${r.id}`} className="text-blue-600">
+                    {r.subject}
+                  </Link>
+                </td>
+                <td className="p-2">{r.rosterName}</td>
+                <td className="p-2 text-right">{r.present}</td>
+                <td className="p-2 text-right">{r.absent}</td>
+                <td className="p-2 text-center">{r.locked ? '🔒' : ''}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/components/AttendanceTable.jsx
+++ b/components/AttendanceTable.jsx
@@ -1,0 +1,139 @@
+'use client';
+import { useState } from 'react';
+
+export default function AttendanceTable({ sessionId, locked, records }) {
+  const [data, setData] = useState(records);
+  const [history, setHistory] = useState([]);
+  const [query, setQuery] = useState('');
+  const [isLocked, setIsLocked] = useState(locked);
+
+  const filtered = data.filter(
+    (r) =>
+      r.name.toLowerCase().includes(query.toLowerCase()) ||
+      r.enrollmentNumber.toLowerCase().includes(query.toLowerCase())
+  );
+
+  function updateStatus(id, status) {
+    setHistory([...history, data]);
+    setData(data.map((r) => (r.studentId === id ? { ...r, status } : r)));
+  }
+
+  function markAll(status) {
+    setHistory([...history, data]);
+    setData(data.map((r) => ({ ...r, status })));
+  }
+
+  function undo() {
+    const prev = history.pop();
+    if (prev) {
+      setData(prev);
+      setHistory([...history]);
+    }
+  }
+
+  async function save() {
+    await fetch(`/api/sessions/${sessionId}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        records: data.map((r) => ({ studentId: r.studentId, status: r.status })),
+      }),
+    });
+  }
+
+  async function toggleLock() {
+    await fetch(`/api/sessions/${sessionId}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ records: [], locked: !isLocked }),
+    });
+    setIsLocked(!isLocked);
+  }
+
+  function rowClass(status) {
+    return status === 'PRESENT' ? 'table-row-present' : 'table-row-absent';
+  }
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-4">
+        <button
+          onClick={() => markAll('PRESENT')}
+          className="bg-green-500 text-white px-2 py-1 rounded"
+          type="button"
+        >
+          Mark All Present
+        </button>
+        <button
+          onClick={() => markAll('ABSENT')}
+          className="bg-red-500 text-white px-2 py-1 rounded"
+          type="button"
+        >
+          Mark All Absent
+        </button>
+        <button onClick={undo} className="px-2 py-1 border rounded" type="button">
+          Undo
+        </button>
+        <input
+          placeholder="Search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="border p-1 flex-grow"
+        />
+        <button onClick={save} className="bg-blue-500 text-white px-4 py-1 rounded" type="button">
+          Save
+        </button>
+        <button onClick={toggleLock} className="px-2 py-1 border rounded" type="button">
+          {isLocked ? 'Unlock' : 'Lock'}
+        </button>
+        <a href={`/api/sessions/${sessionId}/export`} className="px-2 py-1 border rounded">
+          Export CSV
+        </a>
+      </div>
+      {isLocked && <div className="p-2 bg-yellow-100 mb-2">Session is locked</div>}
+      <div className="overflow-auto">
+        <table className="min-w-full bg-white rounded shadow">
+          <thead>
+            <tr>
+              <th className="p-2 text-left">Enrollment</th>
+              <th className="p-2 text-left">Name</th>
+              <th className="p-2">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((r) => (
+              <tr key={r.studentId} className={`border-t ${rowClass(r.status)}`}>
+                <td className="p-2">{r.enrollmentNumber}</td>
+                <td className="p-2">{r.name}</td>
+                <td className="p-2">
+                  <label className="mr-2">
+                    <input
+                      type="radio"
+                      name={`status-${r.studentId}`}
+                      value="PRESENT"
+                      disabled={isLocked}
+                      checked={r.status === 'PRESENT'}
+                      onChange={() => updateStatus(r.studentId, 'PRESENT')}
+                    />{' '}
+                    Present
+                  </label>
+                  <label>
+                    <input
+                      type="radio"
+                      name={`status-${r.studentId}`}
+                      value="ABSENT"
+                      disabled={isLocked}
+                      checked={r.status === 'ABSENT'}
+                      onChange={() => updateStatus(r.studentId, 'ABSENT')}
+                    />{' '}
+                    Absent
+                  </label>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["*"]
+    }
+  }
+}

--- a/lib/prisma.js
+++ b/lib/prisma.js
@@ -1,0 +1,11 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis;
+
+export const prisma = globalForPrisma.prisma || new PrismaClient({
+  log: ['error', 'warn'],
+});
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    serverActions: true,
+  },
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "attendance-system",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "prisma:migrate": "prisma migrate deploy",
+    "test": "echo 'No tests'"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "@prisma/client": "5.13.0",
+    "prisma": "5.13.0",
+    "tailwindcss": "3.4.4",
+    "autoprefixer": "10.4.16",
+    "postcss": "8.4.33",
+    "xlsx": "0.18.5",
+    "zod": "3.22.4"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,63 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Roster {
+  id        Int       @id @default(autoincrement())
+  name      String
+  students  Student[]
+  sessions  AttendanceSession[]
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+}
+
+model Student {
+  id               Int      @id @default(autoincrement())
+  roster           Roster   @relation(fields: [rosterId], references: [id], onDelete: Cascade)
+  rosterId         Int
+  name             String
+  enrollmentNumber String
+  extra            Json?
+  notes            String?
+  records          AttendanceRecord[]
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  @@unique([rosterId, enrollmentNumber])
+}
+
+model AttendanceSession {
+  id          Int      @id @default(autoincrement())
+  roster      Roster   @relation(fields: [rosterId], references: [id], onDelete: Cascade)
+  rosterId    Int
+  subject     String
+  sessionDate DateTime @db.Date
+  locked      Boolean  @default(false)
+  records     AttendanceRecord[]
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+
+enum Status {
+  PRESENT
+  ABSENT
+}
+
+model AttendanceRecord {
+  id        Int              @id @default(autoincrement())
+  session   AttendanceSession @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  sessionId Int
+  student   Student          @relation(fields: [studentId], references: [id], onDelete: Cascade)
+  studentId Int
+  status    Status           @default(PRESENT)
+  notes     String?
+  createdAt DateTime         @default(now())
+  updatedAt DateTime         @updatedAt
+
+  @@unique([sessionId, studentId])
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    "./app/**/*.{js,jsx}",
+    "./components/**/*.{js,jsx}"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- scaffold Next.js attendance app with Tailwind and Prisma
- support rosters, imports, attendance sessions and CSV exports
- add dynamic student fields stored as JSONB

## Testing
- `npx -y prisma validate`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b968fa0ed88326b4a89b78bb7f6806