### PR TITLE
feat: improve roster management

### DIFF
--- a/app/rosters/[id]/page.jsx
+++ b/app/rosters/[id]/page.jsx
@@ -1,4 +1,5 @@
 import { prisma } from '@/lib/prisma';
+import { revalidatePath } from 'next/cache';
 import * as XLSX from 'xlsx';
 
 export default async function RosterPage({ params }) {
@@ -25,10 +26,35 @@ export default async function RosterPage({ params }) {
     const rows = XLSX.utils.sheet_to_json(sheet, { defval: '' });
     const students = rows
       .map((row) => {
-        const { enrollmentNumber, name, ...extra } = row;
+        const get = (...keys) => {
+          for (const k of keys) {
+            if (row[k] !== undefined && row[k] !== '') return row[k];
+          }
+        };
+        const enrollmentNumber = get(
+          'enrollmentNumber',
+          'EnrollmentNumber',
+          'enrollmentnumber'
+        );
+        const name = get('name', 'Name');
+        const first = get('firstName', 'First Name', 'firstname');
+        const last = get('lastName', 'Last Name', 'lastname');
+        const fullName = name || [first, last].filter(Boolean).join(' ');
+        const extra = { ...row };
+        delete extra.enrollmentNumber;
+        delete extra.EnrollmentNumber;
+        delete extra.enrollmentnumber;
+        delete extra.name;
+        delete extra.Name;
+        delete extra.firstName;
+        delete extra['First Name'];
+        delete extra.firstname;
+        delete extra.lastName;
+        delete extra['Last Name'];
+        delete extra.lastname;
         return {
-          enrollmentNumber: String(enrollmentNumber),
-          name: String(name),
+          enrollmentNumber: String(enrollmentNumber || ''),
+          name: String(fullName || ''),
           extra,
         };
       })
@@ -42,17 +68,67 @@ export default async function RosterPage({ params }) {
     await prisma.$transaction(async (tx) => {
       for (const s of unique) {
         await tx.student.upsert({
-          where: { rosterId_enrollmentNumber: { rosterId, enrollmentNumber: s.enrollmentNumber } },
+          where: {
+            rosterId_enrollmentNumber: { rosterId, enrollmentNumber: s.enrollmentNumber },
+          },
           update: { name: s.name, extra: s.extra },
-          create: { rosterId, name: s.name, enrollmentNumber: s.enrollmentNumber, extra: s.extra },
+          create: {
+            rosterId,
+            name: s.name,
+            enrollmentNumber: s.enrollmentNumber,
+            extra: s.extra,
+          },
         });
       }
     });
+    revalidatePath(`/rosters/${rosterId}`);
+  }
+
+  async function addStudent(formData) {
+    'use server';
+    const enrollmentNumber = formData.get('enrollmentNumber');
+    const name = formData.get('name');
+    if (!enrollmentNumber || !name) return;
+    await prisma.student.upsert({
+      where: {
+        rosterId_enrollmentNumber: {
+          rosterId,
+          enrollmentNumber: String(enrollmentNumber),
+        },
+      },
+      update: { name: String(name) },
+      create: {
+        rosterId,
+        enrollmentNumber: String(enrollmentNumber),
+        name: String(name),
+      },
+    });
+    revalidatePath(`/rosters/${rosterId}`);
   }
 
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">{roster.name}</h1>
+      <form action={addStudent} className="mb-4 flex gap-2">
+        <input
+          type="text"
+          name="enrollmentNumber"
+          placeholder="Enrollment #"
+          className="border p-2"
+          required
+        />
+        <input
+          type="text"
+          name="name"
+          placeholder="Student name"
+          className="border p-2 flex-grow"
+          required
+        />
+        <button className="bg-blue-500 text-white px-4 py-2 rounded">
+          Add Student
+        </button>
+      </form>
+
       <form
         action={importAction}
         className="mb-4 flex gap-2"

--- a/app/rosters/page.jsx
+++ b/app/rosters/page.jsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { revalidatePath } from 'next/cache';
 import { prisma } from '@/lib/prisma';
 
 export default async function RostersPage() {
@@ -9,6 +10,15 @@ export default async function RostersPage() {
     const name = formData.get('name');
     if (!name) return;
     await prisma.roster.create({ data: { name } });
+    revalidatePath('/rosters');
+  }
+
+  async function deleteRoster(formData) {
+    'use server';
+    const id = Number(formData.get('id'));
+    if (!id) return;
+    await prisma.roster.delete({ where: { id } });
+    revalidatePath('/rosters');
   }
 
   return (
@@ -26,8 +36,23 @@ export default async function RostersPage() {
       </form>
       <ul className="space-y-2">
         {rosters.map((r) => (
-          <li key={r.id} className="p-2 bg-white rounded shadow">
-            <Link href={`/rosters/${r.id}`}>{r.name}</Link>
+          <li
+            key={r.id}
+            className="p-2 bg-white rounded shadow flex items-center justify-between"
+          >
+            <Link href={`/rosters/${r.id}`} className="flex-grow">
+              {r.name}
+            </Link>
+            <form action={deleteRoster}>
+              <input type="hidden" name="id" value={r.id} />
+              <button
+                type="submit"
+                className="ml-4 text-red-600 hover:text-red-800"
+                aria-label="Delete roster"
+              >
+                Delete
+              </button>
+            </form>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- allow creating and deleting rosters with automatic refresh
- enable manual student entry and better spreadsheet import
- update pages to refresh after roster changes

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b973ac662c8326b6423fd0d887b36e