### PR TITLE
Improve roster management and UI

### DIFF
--- a/app/rosters/page.jsx
+++ b/app/rosters/page.jsx
@@ -22,32 +22,37 @@ export default async function RostersPage() {
   }
 
   return (
-    <div>
-      <h1 className="text-2xl font-bold mb-4">Rosters</h1>
-      <form action={createRoster} className="mb-4 flex gap-2">
+    <div className="max-w-4xl mx-auto p-6 space-y-6">
+      <h1 className="text-3xl font-semibold">Rosters</h1>
+      <form action={createRoster} className="flex flex-wrap gap-2">
         <input
           type="text"
           name="name"
           placeholder="New roster name"
-          className="border p-2 flex-grow"
+          className="border p-2 rounded flex-grow"
           required
         />
-        <button className="bg-blue-500 text-white px-4 py-2 rounded">Add</button>
+        <button className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+          Add
+        </button>
       </form>
       <ul className="space-y-2">
         {rosters.map((r) => (
           <li
             key={r.id}
-            className="p-2 bg-white rounded shadow flex items-center justify-between"
+            className="p-4 bg-white rounded shadow flex items-center justify-between"
           >
-            <Link href={`/rosters/${r.id}`} className="flex-grow">
+            <Link
+              href={`/rosters/${r.id}`}
+              className="flex-grow text-blue-700 hover:underline"
+            >
               {r.name}
             </Link>
             <form action={deleteRoster}>
               <input type="hidden" name="id" value={r.id} />
               <button
                 type="submit"
-                className="ml-4 text-red-600 hover:text-red-800"
+                className="ml-4 text-red-600 hover:underline"
                 aria-label="Delete roster"
               >
                 Delete


### PR DESCRIPTION
## Summary
- fix Excel/CSV import by loading `xlsx` dynamically
- add ability to delete students from a roster
- modernize roster pages with refreshed Tailwind styling

## Testing
- `npm test`
- `npm run build` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68b976c5ae9c832683ec347422eb7793