### PR TITLE
fix: remove obsolete enctype from import form

### DIFF
--- a/app/rosters/[id]/page.jsx
+++ b/app/rosters/[id]/page.jsx
@@ -142,7 +142,6 @@ export default async function RosterPage({ params }) {
       <form
         action={importAction}
         className="flex flex-col sm:flex-row gap-2"
-        encType="multipart/form-data"
       >
         <input
           type="file"


### PR DESCRIPTION
## Summary
- avoid overriding Next.js server action defaults by removing explicit `encType`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b980ac6de4832686fbbdfdbad6a507